### PR TITLE
Improve clearing the current console line

### DIFF
--- a/Kurukuru/ConsoleHelper.cs
+++ b/Kurukuru/ConsoleHelper.cs
@@ -30,13 +30,13 @@ namespace Kurukuru
         }
 
         // See: https://stackoverflow.com/questions/8946808/can-console-clear-be-used-to-only-clear-a-line-instead-of-whole-console/8946847#8946847
-        public static void ClearCurrentConsoleLine()
+        public static void ClearCurrentConsoleLine(int length)
         {
-            if (Console.IsOutputRedirected) return;
+            if (Console.IsOutputRedirected || length == 0) return;
 
             int currentLineCursor = Console.CursorTop;
             Console.SetCursorPosition(0, Console.CursorTop);
-            Console.Write(new string(' ', Console.WindowWidth));
+            Console.Write(new string(' ', length));
             Console.SetCursorPosition(0, currentLineCursor);
             Console.Out.Flush();
         }

--- a/Kurukuru/Spinner.cs
+++ b/Kurukuru/Spinner.cs
@@ -11,6 +11,7 @@ namespace Kurukuru
         private Pattern _pattern;
         private Pattern _fallbackPattern;
         private int _frameIndex;
+        private int _lineLength;
         private bool _enabled;
 
         public bool Stopped { get; private set; }
@@ -76,10 +77,12 @@ namespace Kurukuru
 
         private void Render()
         {
-            ConsoleHelper.ClearCurrentConsoleLine();
-
             var pattern = CurrentPattern;
             var frame = pattern.Frames[_frameIndex++ % pattern.Frames.Length];
+
+            ConsoleHelper.ClearCurrentConsoleLine(_lineLength);
+            _lineLength = frame.Length + 1 + Text.Length;
+
             ConsoleHelper.WriteWithColor(frame, Color ?? Console.ForegroundColor);
             Console.Write(" ");
             Console.Write(Text);


### PR DESCRIPTION
Clear the previously written line instead of clearing the whole console window width. This way, when resizing the console window, lines don't wrap.

Here's a GIF to better understand what happens. The first two message batches use the console width (code before this commit). The last two message batches use the new code that clear only what's needed. Dots have been added (second and fourth samples) instead of spaces to better see why line wraps.

![clear-console-line](https://user-images.githubusercontent.com/51363/102675006-2f570a80-4198-11eb-87df-3b3960ba4006.gif)
