### PR TITLE
Allow multiple spinners

### DIFF
--- a/Kurukuru.Sample/Program.cs
+++ b/Kurukuru.Sample/Program.cs
@@ -10,6 +10,8 @@ namespace Kurukuru.Sample
         {
             System.Console.OutputEncoding = System.Text.Encoding.UTF8;
 
+            // for (var i = 0; i < 10000; i++) { Console.WriteLine(i); }
+
             using (var spinner = new Spinner("Initializing...", Patterns.Dots12))
             {
                 spinner.Start();

--- a/Kurukuru.Sample/Properties/launchSettings.json
+++ b/Kurukuru.Sample/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Kurukuru": {
+      "commandName": "Project",
+      "environmentVariables": {
+        //"CI": "1"
+      }
+    }
+  }
+}

--- a/Kurukuru/ConsoleHelper.cs
+++ b/Kurukuru/ConsoleHelper.cs
@@ -47,21 +47,20 @@ namespace Kurukuru
         }
 
         // See: https://stackoverflow.com/questions/8946808/can-console-clear-be-used-to-only-clear-a-line-instead-of-whole-console/8946847#8946847
-        public static void ClearCurrentConsoleLine(int length)
+        public static void ClearCurrentConsoleLine(int length, int top)
         {
-            if (Console.IsOutputRedirected || length == 0) return;
+            if (Console.IsOutputRedirected) return;
 
             if (CanAcceptEscapeSequence)
             {
-                Console.SetCursorPosition(0, Console.CursorTop);
+                Console.SetCursorPosition(0, top);
                 Console.Write("\u001B[2K");
             }
             else
             {
-                int currentLineCursor = Console.CursorTop;
-                Console.SetCursorPosition(0, Console.CursorTop);
+                Console.SetCursorPosition(0, top);
                 Console.Write(new string(' ', length));
-                Console.SetCursorPosition(0, currentLineCursor);
+                Console.SetCursorPosition(0, top);
             }
             Console.Out.Flush();
         }

--- a/Kurukuru/Spinner.cs
+++ b/Kurukuru/Spinner.cs
@@ -121,7 +121,7 @@ namespace Kurukuru
                     var currentLeft = Console.CursorLeft;
                     var currentTop = Console.CursorTop;
 
-                    ConsoleHelper.ClearCurrentConsoleLine(_lineLength, _cursorTop);
+                    ConsoleHelper.ClearCurrentConsoleLine(_lineLength, _enabled ? _cursorTop : currentTop);
                     ConsoleHelper.WriteWithColor(frame, Color ?? Console.ForegroundColor);
                     Console.Write(" ");
                     Console.Write(Text);
@@ -129,7 +129,10 @@ namespace Kurukuru
                     Console.Write(terminator);
                     Console.Out.Flush();
 
-                    Console.SetCursorPosition(currentLeft, currentTop);
+                    if (_enabled)
+                    {
+                        Console.SetCursorPosition(currentLeft, currentTop);
+                    }
                 }
             }
         }
@@ -162,10 +165,13 @@ namespace Kurukuru
             lock (s_consoleLock)
             {
                 Render(terminator);
-                s_runningSpinnerCount--;
-                if (s_runningSpinnerCount == 0)
+                if (_enabled)
                 {
-                    ConsoleHelper.SetCursorVisibility(true);
+                    s_runningSpinnerCount--;
+                    if (s_runningSpinnerCount == 0)
+                    {
+                        ConsoleHelper.SetCursorVisibility(true);
+                    }
                 }
             }
         }

--- a/Kurukuru/Spinner.cs
+++ b/Kurukuru/Spinner.cs
@@ -120,10 +120,10 @@ namespace Kurukuru
                 ConsoleHelper.WriteWithColor(frame, Color ?? Console.ForegroundColor);
                 Console.Write(" ");
                 Console.Write(Text);
+                _lineLength = Console.CursorLeft; // get line length before write terminator
                 Console.Write(terminator);
                 Console.Out.Flush();
 
-                _lineLength = Console.CursorLeft;
                 Console.SetCursorPosition(currentLeft, currentTop);
             }
         }


### PR DESCRIPTION
Currently Spinner can not run multiple in multi-threading.
![broken](https://user-images.githubusercontent.com/46207/144668306-361bf40b-a69a-4c2c-816f-ecae62389a89.gif)

This PR stores CursorTop and lock Console operations.

![fixed](https://user-images.githubusercontent.com/46207/144668315-8d9f67ff-bf70-4782-b5f0-e13f1c028712.gif)

Also I've found bug of `!CanAcceptEscapeSequence`'s clear line code.

![broken_clear](https://user-images.githubusercontent.com/46207/144668446-7d93a8e1-88ac-42ec-a190-d075dff5dfac.gif)

`_lineLength = frame.Length + 1 + Text.Length;` is not work for non-ascii character.
I've modified to ` _lineLength = Console.CursorLeft;` after console out flushed.