### PR TITLE
Update patterns

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.x'
+        dotnet-version: '8.0.x'
 
     # Build
     - run: dotnet restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.x'
+        dotnet-version: '8.0.x'
 
     - name: "dotnet build & pack"
       run: |

--- a/Kurukuru.Sample/Kurukuru.Sample.csproj
+++ b/Kurukuru.Sample/Kurukuru.Sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Kurukuru.sln
+++ b/Kurukuru.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
 		README.md = README.md
+		UpdatePatterns.js = UpdatePatterns.js
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GitHub Actions", "GitHub Actions", "{FC83AC91-80D8-4847-A69D-887138048F2A}"

--- a/Kurukuru/Kurukuru.csproj
+++ b/Kurukuru/Kurukuru.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>

--- a/Kurukuru/Pattern.cs
+++ b/Kurukuru/Pattern.cs
@@ -1,0 +1,14 @@
+namespace Kurukuru
+{
+    public class Pattern
+    {
+        public string[] Frames { get; }
+        public int Interval { get; }
+
+        public Pattern(string[] frames, int interval)
+        {
+            Frames = frames;
+            Interval = interval;
+        }
+    }
+}

--- a/Kurukuru/Patterns.cs
+++ b/Kurukuru/Patterns.cs
@@ -1,15 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace Kurukuru
 {
     // The patterns are ripped off https://github.com/sindresorhus/cli-spinners
-    // Object.keys(json).map(x => ({ key: x[0].toUpperCase() + x.substring(1), value: json[x] })).map(x => [`        public static readonly Pattern ${x.key} = new Pattern(new string[]`, `        {`, x.value.frames.map(x => '            "' + x.replace('\\', '\\\\') + '"').join(",\n"), `        }, interval: ${x.value.interval});`].join("\n")).join("\n\n")
     public class Patterns
     {
-        public static readonly Pattern Dots = new Pattern(new string[]
-        {
+        public static readonly Pattern Dots = new([
             "⠋",
             "⠙",
             "⠹",
@@ -20,10 +14,9 @@ namespace Kurukuru
             "⠧",
             "⠇",
             "⠏"
-        }, interval: 80);
+        ], interval: 80);
 
-        public static readonly Pattern Dots2 = new Pattern(new string[]
-        {
+        public static readonly Pattern Dots2 = new([
             "⣾",
             "⣽",
             "⣻",
@@ -32,10 +25,9 @@ namespace Kurukuru
             "⣟",
             "⣯",
             "⣷"
-        }, interval: 80);
+        ], interval: 80);
 
-        public static readonly Pattern Dots3 = new Pattern(new string[]
-        {
+        public static readonly Pattern Dots3 = new([
             "⠋",
             "⠙",
             "⠚",
@@ -46,10 +38,9 @@ namespace Kurukuru
             "⠲",
             "⠳",
             "⠓"
-        }, interval: 80);
+        ], interval: 80);
 
-        public static readonly Pattern Dots4 = new Pattern(new string[]
-        {
+        public static readonly Pattern Dots4 = new([
             "⠄",
             "⠆",
             "⠇",
@@ -64,10 +55,9 @@ namespace Kurukuru
             "⠋",
             "⠇",
             "⠆"
-        }, interval: 80);
+        ], interval: 80);
 
-        public static readonly Pattern Dots5 = new Pattern(new string[]
-        {
+        public static readonly Pattern Dots5 = new([
             "⠋",
             "⠙",
             "⠚",
@@ -85,10 +75,9 @@ namespace Kurukuru
             "⠒",
             "⠓",
             "⠋"
-        }, interval: 80);
+        ], interval: 80);
 
-        public static readonly Pattern Dots6 = new Pattern(new string[]
-        {
+        public static readonly Pattern Dots6 = new([
             "⠁",
             "⠉",
             "⠙",
@@ -113,10 +102,9 @@ namespace Kurukuru
             "⠙",
             "⠉",
             "⠁"
-        }, interval: 80);
+        ], interval: 80);
 
-        public static readonly Pattern Dots7 = new Pattern(new string[]
-        {
+        public static readonly Pattern Dots7 = new([
             "⠈",
             "⠉",
             "⠋",
@@ -141,10 +129,9 @@ namespace Kurukuru
             "⠋",
             "⠉",
             "⠈"
-        }, interval: 80);
+        ], interval: 80);
 
-        public static readonly Pattern Dots8 = new Pattern(new string[]
-        {
+        public static readonly Pattern Dots8 = new([
             "⠁",
             "⠁",
             "⠉",
@@ -174,10 +161,9 @@ namespace Kurukuru
             "⠉",
             "⠈",
             "⠈"
-        }, interval: 80);
+        ], interval: 80);
 
-        public static readonly Pattern Dots9 = new Pattern(new string[]
-        {
+        public static readonly Pattern Dots9 = new([
             "⢹",
             "⢺",
             "⢼",
@@ -186,10 +172,9 @@ namespace Kurukuru
             "⡧",
             "⡗",
             "⡏"
-        }, interval: 80);
+        ], interval: 80);
 
-        public static readonly Pattern Dots10 = new Pattern(new string[]
-        {
+        public static readonly Pattern Dots10 = new([
             "⢄",
             "⢂",
             "⢁",
@@ -197,10 +182,9 @@ namespace Kurukuru
             "⡈",
             "⡐",
             "⡠"
-        }, interval: 80);
+        ], interval: 80);
 
-        public static readonly Pattern Dots11 = new Pattern(new string[]
-        {
+        public static readonly Pattern Dots11 = new([
             "⠁",
             "⠂",
             "⠄",
@@ -209,10 +193,9 @@ namespace Kurukuru
             "⠠",
             "⠐",
             "⠈"
-        }, interval: 100);
+        ], interval: 100);
 
-        public static readonly Pattern Dots12 = new Pattern(new string[]
-        {
+        public static readonly Pattern Dots12 = new([
             "⢀⠀",
             "⡀⠀",
             "⠄⠀",
@@ -269,28 +252,359 @@ namespace Kurukuru
             "⠀⠠",
             "⠀⢀",
             "⠀⡀"
-        }, interval: 80);
+        ], interval: 80);
 
-        public static readonly Pattern Line = new Pattern(new string[]
-        {
+        public static readonly Pattern Dots13 = new([
+            "⣼",
+            "⣹",
+            "⢻",
+            "⠿",
+            "⡟",
+            "⣏",
+            "⣧",
+            "⣶"
+        ], interval: 80);
+
+        public static readonly Pattern Dots14 = new([
+            "⠉⠉",
+            "⠈⠙",
+            "⠀⠹",
+            "⠀⢸",
+            "⠀⣰",
+            "⢀⣠",
+            "⣀⣀",
+            "⣄⡀",
+            "⣆⠀",
+            "⡇⠀",
+            "⠏⠀",
+            "⠋⠁"
+        ], interval: 80);
+
+        public static readonly Pattern Dots8Bit = new([
+            "⠀",
+            "⠁",
+            "⠂",
+            "⠃",
+            "⠄",
+            "⠅",
+            "⠆",
+            "⠇",
+            "⡀",
+            "⡁",
+            "⡂",
+            "⡃",
+            "⡄",
+            "⡅",
+            "⡆",
+            "⡇",
+            "⠈",
+            "⠉",
+            "⠊",
+            "⠋",
+            "⠌",
+            "⠍",
+            "⠎",
+            "⠏",
+            "⡈",
+            "⡉",
+            "⡊",
+            "⡋",
+            "⡌",
+            "⡍",
+            "⡎",
+            "⡏",
+            "⠐",
+            "⠑",
+            "⠒",
+            "⠓",
+            "⠔",
+            "⠕",
+            "⠖",
+            "⠗",
+            "⡐",
+            "⡑",
+            "⡒",
+            "⡓",
+            "⡔",
+            "⡕",
+            "⡖",
+            "⡗",
+            "⠘",
+            "⠙",
+            "⠚",
+            "⠛",
+            "⠜",
+            "⠝",
+            "⠞",
+            "⠟",
+            "⡘",
+            "⡙",
+            "⡚",
+            "⡛",
+            "⡜",
+            "⡝",
+            "⡞",
+            "⡟",
+            "⠠",
+            "⠡",
+            "⠢",
+            "⠣",
+            "⠤",
+            "⠥",
+            "⠦",
+            "⠧",
+            "⡠",
+            "⡡",
+            "⡢",
+            "⡣",
+            "⡤",
+            "⡥",
+            "⡦",
+            "⡧",
+            "⠨",
+            "⠩",
+            "⠪",
+            "⠫",
+            "⠬",
+            "⠭",
+            "⠮",
+            "⠯",
+            "⡨",
+            "⡩",
+            "⡪",
+            "⡫",
+            "⡬",
+            "⡭",
+            "⡮",
+            "⡯",
+            "⠰",
+            "⠱",
+            "⠲",
+            "⠳",
+            "⠴",
+            "⠵",
+            "⠶",
+            "⠷",
+            "⡰",
+            "⡱",
+            "⡲",
+            "⡳",
+            "⡴",
+            "⡵",
+            "⡶",
+            "⡷",
+            "⠸",
+            "⠹",
+            "⠺",
+            "⠻",
+            "⠼",
+            "⠽",
+            "⠾",
+            "⠿",
+            "⡸",
+            "⡹",
+            "⡺",
+            "⡻",
+            "⡼",
+            "⡽",
+            "⡾",
+            "⡿",
+            "⢀",
+            "⢁",
+            "⢂",
+            "⢃",
+            "⢄",
+            "⢅",
+            "⢆",
+            "⢇",
+            "⣀",
+            "⣁",
+            "⣂",
+            "⣃",
+            "⣄",
+            "⣅",
+            "⣆",
+            "⣇",
+            "⢈",
+            "⢉",
+            "⢊",
+            "⢋",
+            "⢌",
+            "⢍",
+            "⢎",
+            "⢏",
+            "⣈",
+            "⣉",
+            "⣊",
+            "⣋",
+            "⣌",
+            "⣍",
+            "⣎",
+            "⣏",
+            "⢐",
+            "⢑",
+            "⢒",
+            "⢓",
+            "⢔",
+            "⢕",
+            "⢖",
+            "⢗",
+            "⣐",
+            "⣑",
+            "⣒",
+            "⣓",
+            "⣔",
+            "⣕",
+            "⣖",
+            "⣗",
+            "⢘",
+            "⢙",
+            "⢚",
+            "⢛",
+            "⢜",
+            "⢝",
+            "⢞",
+            "⢟",
+            "⣘",
+            "⣙",
+            "⣚",
+            "⣛",
+            "⣜",
+            "⣝",
+            "⣞",
+            "⣟",
+            "⢠",
+            "⢡",
+            "⢢",
+            "⢣",
+            "⢤",
+            "⢥",
+            "⢦",
+            "⢧",
+            "⣠",
+            "⣡",
+            "⣢",
+            "⣣",
+            "⣤",
+            "⣥",
+            "⣦",
+            "⣧",
+            "⢨",
+            "⢩",
+            "⢪",
+            "⢫",
+            "⢬",
+            "⢭",
+            "⢮",
+            "⢯",
+            "⣨",
+            "⣩",
+            "⣪",
+            "⣫",
+            "⣬",
+            "⣭",
+            "⣮",
+            "⣯",
+            "⢰",
+            "⢱",
+            "⢲",
+            "⢳",
+            "⢴",
+            "⢵",
+            "⢶",
+            "⢷",
+            "⣰",
+            "⣱",
+            "⣲",
+            "⣳",
+            "⣴",
+            "⣵",
+            "⣶",
+            "⣷",
+            "⢸",
+            "⢹",
+            "⢺",
+            "⢻",
+            "⢼",
+            "⢽",
+            "⢾",
+            "⢿",
+            "⣸",
+            "⣹",
+            "⣺",
+            "⣻",
+            "⣼",
+            "⣽",
+            "⣾",
+            "⣿"
+        ], interval: 80);
+
+        public static readonly Pattern DotsCircle = new([
+            "⢎ ",
+            "⠎⠁",
+            "⠊⠑",
+            "⠈⠱",
+            " ⡱",
+            "⢀⡰",
+            "⢄⡠",
+            "⢆⡀"
+        ], interval: 80);
+
+        public static readonly Pattern Sand = new([
+            "⠁",
+            "⠂",
+            "⠄",
+            "⡀",
+            "⡈",
+            "⡐",
+            "⡠",
+            "⣀",
+            "⣁",
+            "⣂",
+            "⣄",
+            "⣌",
+            "⣔",
+            "⣤",
+            "⣥",
+            "⣦",
+            "⣮",
+            "⣶",
+            "⣷",
+            "⣿",
+            "⡿",
+            "⠿",
+            "⢟",
+            "⠟",
+            "⡛",
+            "⠛",
+            "⠫",
+            "⢋",
+            "⠋",
+            "⠍",
+            "⡉",
+            "⠉",
+            "⠑",
+            "⠡",
+            "⢁"
+        ], interval: 80);
+
+        public static readonly Pattern Line = new([
             "-",
             "\\",
             "|",
             "/"
-        }, interval: 130);
+        ], interval: 130);
 
-        public static readonly Pattern Line2 = new Pattern(new string[]
-        {
+        public static readonly Pattern Line2 = new([
             "⠂",
             "-",
             "–",
             "—",
             "–",
             "-"
-        }, interval: 100);
+        ], interval: 100);
 
-        public static readonly Pattern Pipe = new Pattern(new string[]
-        {
+        public static readonly Pattern Pipe = new([
             "┤",
             "┘",
             "┴",
@@ -299,45 +613,40 @@ namespace Kurukuru
             "┌",
             "┬",
             "┐"
-        }, interval: 100);
+        ], interval: 100);
 
-        public static readonly Pattern SimpleDots = new Pattern(new string[]
-        {
+        public static readonly Pattern SimpleDots = new([
             ".  ",
             ".. ",
             "...",
             "   "
-        }, interval: 400);
+        ], interval: 400);
 
-        public static readonly Pattern SimpleDotsScrolling = new Pattern(new string[]
-        {
+        public static readonly Pattern SimpleDotsScrolling = new([
             ".  ",
             ".. ",
             "...",
             " ..",
             "  .",
             "   "
-        }, interval: 200);
+        ], interval: 200);
 
-        public static readonly Pattern Star = new Pattern(new string[]
-        {
+        public static readonly Pattern Star = new([
             "✶",
             "✸",
             "✹",
             "✺",
             "✹",
             "✷"
-        }, interval: 70);
+        ], interval: 70);
 
-        public static readonly Pattern Star2 = new Pattern(new string[]
-        {
+        public static readonly Pattern Star2 = new([
             "+",
             "x",
             "*"
-        }, interval: 80);
+        ], interval: 80);
 
-        public static readonly Pattern Flip = new Pattern(new string[]
-        {
+        public static readonly Pattern Flip = new([
             "_",
             "_",
             "_",
@@ -350,17 +659,15 @@ namespace Kurukuru
             "_",
             "_",
             "_"
-        }, interval: 70);
+        ], interval: 70);
 
-        public static readonly Pattern Hamburger = new Pattern(new string[]
-        {
+        public static readonly Pattern Hamburger = new([
             "☱",
             "☲",
             "☴"
-        }, interval: 100);
+        ], interval: 100);
 
-        public static readonly Pattern GrowVertical = new Pattern(new string[]
-        {
+        public static readonly Pattern GrowVertical = new([
             "▁",
             "▃",
             "▄",
@@ -371,10 +678,9 @@ namespace Kurukuru
             "▅",
             "▄",
             "▃"
-        }, interval: 120);
+        ], interval: 120);
 
-        public static readonly Pattern GrowHorizontal = new Pattern(new string[]
-        {
+        public static readonly Pattern GrowHorizontal = new([
             "▏",
             "▎",
             "▍",
@@ -387,10 +693,9 @@ namespace Kurukuru
             "▌",
             "▍",
             "▎"
-        }, interval: 120);
+        ], interval: 120);
 
-        public static readonly Pattern Balloon = new Pattern(new string[]
-        {
+        public static readonly Pattern Balloon = new([
             " ",
             ".",
             "o",
@@ -398,10 +703,9 @@ namespace Kurukuru
             "@",
             "*",
             " "
-        }, interval: 140);
+        ], interval: 140);
 
-        public static readonly Pattern Balloon2 = new Pattern(new string[]
-        {
+        public static readonly Pattern Balloon2 = new([
             ".",
             "o",
             "O",
@@ -409,178 +713,166 @@ namespace Kurukuru
             "O",
             "o",
             "."
-        }, interval: 120);
+        ], interval: 120);
 
-        public static readonly Pattern Noise = new Pattern(new string[]
-        {
+        public static readonly Pattern Noise = new([
             "▓",
             "▒",
             "░"
-        }, interval: 100);
+        ], interval: 100);
 
-        public static readonly Pattern Bounce = new Pattern(new string[]
-        {
+        public static readonly Pattern Bounce = new([
             "⠁",
             "⠂",
             "⠄",
             "⠂"
-        }, interval: 120);
+        ], interval: 120);
 
-        public static readonly Pattern BoxBounce = new Pattern(new string[]
-        {
+        public static readonly Pattern BoxBounce = new([
             "▖",
             "▘",
             "▝",
             "▗"
-        }, interval: 120);
+        ], interval: 120);
 
-        public static readonly Pattern BoxBounce2 = new Pattern(new string[]
-        {
+        public static readonly Pattern BoxBounce2 = new([
             "▌",
             "▀",
             "▐",
             "▄"
-        }, interval: 100);
+        ], interval: 100);
 
-        public static readonly Pattern Triangle = new Pattern(new string[]
-        {
+        public static readonly Pattern Triangle = new([
             "◢",
             "◣",
             "◤",
             "◥"
-        }, interval: 50);
+        ], interval: 50);
 
-        public static readonly Pattern Arc = new Pattern(new string[]
-        {
+        public static readonly Pattern Binary = new([
+            "010010",
+            "001100",
+            "100101",
+            "111010",
+            "111101",
+            "010111",
+            "101011",
+            "111000",
+            "110011",
+            "110101"
+        ], interval: 80);
+
+        public static readonly Pattern Arc = new([
             "◜",
             "◠",
             "◝",
             "◞",
             "◡",
             "◟"
-        }, interval: 100);
+        ], interval: 100);
 
-        public static readonly Pattern Circle = new Pattern(new string[]
-        {
+        public static readonly Pattern Circle = new([
             "◡",
             "⊙",
             "◠"
-        }, interval: 120);
+        ], interval: 120);
 
-        public static readonly Pattern SquareCorners = new Pattern(new string[]
-        {
+        public static readonly Pattern SquareCorners = new([
             "◰",
             "◳",
             "◲",
             "◱"
-        }, interval: 180);
+        ], interval: 180);
 
-        public static readonly Pattern CircleQuarters = new Pattern(new string[]
-        {
+        public static readonly Pattern CircleQuarters = new([
             "◴",
             "◷",
             "◶",
             "◵"
-        }, interval: 120);
+        ], interval: 120);
 
-        public static readonly Pattern CircleHalves = new Pattern(new string[]
-        {
+        public static readonly Pattern CircleHalves = new([
             "◐",
             "◓",
             "◑",
             "◒"
-        }, interval: 50);
+        ], interval: 50);
 
-        public static readonly Pattern Squish = new Pattern(new string[]
-        {
+        public static readonly Pattern Squish = new([
             "╫",
             "╪"
-        }, interval: 100);
+        ], interval: 100);
 
-        public static readonly Pattern Toggle = new Pattern(new string[]
-        {
+        public static readonly Pattern Toggle = new([
             "⊶",
             "⊷"
-        }, interval: 250);
+        ], interval: 250);
 
-        public static readonly Pattern Toggle2 = new Pattern(new string[]
-        {
+        public static readonly Pattern Toggle2 = new([
             "▫",
             "▪"
-        }, interval: 80);
+        ], interval: 80);
 
-        public static readonly Pattern Toggle3 = new Pattern(new string[]
-        {
+        public static readonly Pattern Toggle3 = new([
             "□",
             "■"
-        }, interval: 120);
+        ], interval: 120);
 
-        public static readonly Pattern Toggle4 = new Pattern(new string[]
-        {
+        public static readonly Pattern Toggle4 = new([
             "■",
             "□",
             "▪",
             "▫"
-        }, interval: 100);
+        ], interval: 100);
 
-        public static readonly Pattern Toggle5 = new Pattern(new string[]
-        {
+        public static readonly Pattern Toggle5 = new([
             "▮",
             "▯"
-        }, interval: 100);
+        ], interval: 100);
 
-        public static readonly Pattern Toggle6 = new Pattern(new string[]
-        {
+        public static readonly Pattern Toggle6 = new([
             "ဝ",
             "၀"
-        }, interval: 300);
+        ], interval: 300);
 
-        public static readonly Pattern Toggle7 = new Pattern(new string[]
-        {
+        public static readonly Pattern Toggle7 = new([
             "⦾",
             "⦿"
-        }, interval: 80);
+        ], interval: 80);
 
-        public static readonly Pattern Toggle8 = new Pattern(new string[]
-        {
+        public static readonly Pattern Toggle8 = new([
             "◍",
             "◌"
-        }, interval: 100);
+        ], interval: 100);
 
-        public static readonly Pattern Toggle9 = new Pattern(new string[]
-        {
+        public static readonly Pattern Toggle9 = new([
             "◉",
             "◎"
-        }, interval: 100);
+        ], interval: 100);
 
-        public static readonly Pattern Toggle10 = new Pattern(new string[]
-        {
+        public static readonly Pattern Toggle10 = new([
             "㊂",
             "㊀",
             "㊁"
-        }, interval: 100);
+        ], interval: 100);
 
-        public static readonly Pattern Toggle11 = new Pattern(new string[]
-        {
+        public static readonly Pattern Toggle11 = new([
             "⧇",
             "⧆"
-        }, interval: 50);
+        ], interval: 50);
 
-        public static readonly Pattern Toggle12 = new Pattern(new string[]
-        {
+        public static readonly Pattern Toggle12 = new([
             "☗",
             "☖"
-        }, interval: 120);
+        ], interval: 120);
 
-        public static readonly Pattern Toggle13 = new Pattern(new string[]
-        {
+        public static readonly Pattern Toggle13 = new([
             "=",
             "*",
             "-"
-        }, interval: 80);
+        ], interval: 80);
 
-        public static readonly Pattern Arrow = new Pattern(new string[]
-        {
+        public static readonly Pattern Arrow = new([
             "←",
             "↖",
             "↑",
@@ -589,10 +881,9 @@ namespace Kurukuru
             "↘",
             "↓",
             "↙"
-        }, interval: 100);
+        ], interval: 100);
 
-        public static readonly Pattern Arrow2 = new Pattern(new string[]
-        {
+        public static readonly Pattern Arrow2 = new([
             "⬆️ ",
             "↗️ ",
             "➡️ ",
@@ -601,24 +892,23 @@ namespace Kurukuru
             "↙️ ",
             "⬅️ ",
             "↖️ "
-        }, interval: 80);
+        ], interval: 80);
 
-        public static readonly Pattern Arrow3 = new Pattern(new string[]
-        {
+        public static readonly Pattern Arrow3 = new([
             "▹▹▹▹▹",
             "▸▹▹▹▹",
             "▹▸▹▹▹",
             "▹▹▸▹▹",
             "▹▹▹▸▹",
             "▹▹▹▹▸"
-        }, interval: 120);
+        ], interval: 120);
 
-        public static readonly Pattern BouncingBar = new Pattern(new string[]
-        {
+        public static readonly Pattern BouncingBar = new([
             "[    ]",
             "[=   ]",
             "[==  ]",
             "[=== ]",
+            "[====]",
             "[ ===]",
             "[  ==]",
             "[   =]",
@@ -630,10 +920,9 @@ namespace Kurukuru
             "[=== ]",
             "[==  ]",
             "[=   ]"
-        }, interval: 80);
+        ], interval: 80);
 
-        public static readonly Pattern BouncingBall = new Pattern(new string[]
-        {
+        public static readonly Pattern BouncingBall = new([
             "( ●    )",
             "(  ●   )",
             "(   ●  )",
@@ -644,33 +933,29 @@ namespace Kurukuru
             "(  ●   )",
             "( ●    )",
             "(●     )"
-        }, interval: 80);
+        ], interval: 80);
 
-        public static readonly Pattern Smiley = new Pattern(new string[]
-        {
+        public static readonly Pattern Smiley = new([
             "😄 ",
             "😝 "
-        }, interval: 200);
+        ], interval: 200);
 
-        public static readonly Pattern Monkey = new Pattern(new string[]
-        {
+        public static readonly Pattern Monkey = new([
             "🙈 ",
             "🙈 ",
             "🙉 ",
             "🙊 "
-        }, interval: 300);
+        ], interval: 300);
 
-        public static readonly Pattern Hearts = new Pattern(new string[]
-        {
+        public static readonly Pattern Hearts = new([
             "💛 ",
             "💙 ",
             "💜 ",
             "💚 ",
             "❤️ "
-        }, interval: 100);
+        ], interval: 100);
 
-        public static readonly Pattern Clock = new Pattern(new string[]
-        {
+        public static readonly Pattern Clock = new([
             "🕛 ",
             "🕐 ",
             "🕑 ",
@@ -683,17 +968,110 @@ namespace Kurukuru
             "🕘 ",
             "🕙 ",
             "🕚 "
-        }, interval: 100);
+        ], interval: 100);
 
-        public static readonly Pattern Earth = new Pattern(new string[]
-        {
+        public static readonly Pattern Earth = new([
             "🌍 ",
             "🌎 ",
             "🌏 "
-        }, interval: 180);
+        ], interval: 180);
 
-        public static readonly Pattern Moon = new Pattern(new string[]
-        {
+        public static readonly Pattern Material = new([
+            "█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁",
+            "██▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁",
+            "███▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁",
+            "████▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁",
+            "██████▁▁▁▁▁▁▁▁▁▁▁▁▁▁",
+            "██████▁▁▁▁▁▁▁▁▁▁▁▁▁▁",
+            "███████▁▁▁▁▁▁▁▁▁▁▁▁▁",
+            "████████▁▁▁▁▁▁▁▁▁▁▁▁",
+            "█████████▁▁▁▁▁▁▁▁▁▁▁",
+            "█████████▁▁▁▁▁▁▁▁▁▁▁",
+            "██████████▁▁▁▁▁▁▁▁▁▁",
+            "███████████▁▁▁▁▁▁▁▁▁",
+            "█████████████▁▁▁▁▁▁▁",
+            "██████████████▁▁▁▁▁▁",
+            "██████████████▁▁▁▁▁▁",
+            "▁██████████████▁▁▁▁▁",
+            "▁██████████████▁▁▁▁▁",
+            "▁██████████████▁▁▁▁▁",
+            "▁▁██████████████▁▁▁▁",
+            "▁▁▁██████████████▁▁▁",
+            "▁▁▁▁█████████████▁▁▁",
+            "▁▁▁▁██████████████▁▁",
+            "▁▁▁▁██████████████▁▁",
+            "▁▁▁▁▁██████████████▁",
+            "▁▁▁▁▁██████████████▁",
+            "▁▁▁▁▁██████████████▁",
+            "▁▁▁▁▁▁██████████████",
+            "▁▁▁▁▁▁██████████████",
+            "▁▁▁▁▁▁▁█████████████",
+            "▁▁▁▁▁▁▁█████████████",
+            "▁▁▁▁▁▁▁▁████████████",
+            "▁▁▁▁▁▁▁▁████████████",
+            "▁▁▁▁▁▁▁▁▁███████████",
+            "▁▁▁▁▁▁▁▁▁███████████",
+            "▁▁▁▁▁▁▁▁▁▁██████████",
+            "▁▁▁▁▁▁▁▁▁▁██████████",
+            "▁▁▁▁▁▁▁▁▁▁▁▁████████",
+            "▁▁▁▁▁▁▁▁▁▁▁▁▁███████",
+            "▁▁▁▁▁▁▁▁▁▁▁▁▁▁██████",
+            "▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█████",
+            "▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█████",
+            "█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁████",
+            "██▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁███",
+            "██▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁███",
+            "███▁▁▁▁▁▁▁▁▁▁▁▁▁▁███",
+            "████▁▁▁▁▁▁▁▁▁▁▁▁▁▁██",
+            "█████▁▁▁▁▁▁▁▁▁▁▁▁▁▁█",
+            "█████▁▁▁▁▁▁▁▁▁▁▁▁▁▁█",
+            "██████▁▁▁▁▁▁▁▁▁▁▁▁▁█",
+            "████████▁▁▁▁▁▁▁▁▁▁▁▁",
+            "█████████▁▁▁▁▁▁▁▁▁▁▁",
+            "█████████▁▁▁▁▁▁▁▁▁▁▁",
+            "█████████▁▁▁▁▁▁▁▁▁▁▁",
+            "█████████▁▁▁▁▁▁▁▁▁▁▁",
+            "███████████▁▁▁▁▁▁▁▁▁",
+            "████████████▁▁▁▁▁▁▁▁",
+            "████████████▁▁▁▁▁▁▁▁",
+            "██████████████▁▁▁▁▁▁",
+            "██████████████▁▁▁▁▁▁",
+            "▁██████████████▁▁▁▁▁",
+            "▁██████████████▁▁▁▁▁",
+            "▁▁▁█████████████▁▁▁▁",
+            "▁▁▁▁▁████████████▁▁▁",
+            "▁▁▁▁▁████████████▁▁▁",
+            "▁▁▁▁▁▁███████████▁▁▁",
+            "▁▁▁▁▁▁▁▁█████████▁▁▁",
+            "▁▁▁▁▁▁▁▁█████████▁▁▁",
+            "▁▁▁▁▁▁▁▁▁█████████▁▁",
+            "▁▁▁▁▁▁▁▁▁█████████▁▁",
+            "▁▁▁▁▁▁▁▁▁▁█████████▁",
+            "▁▁▁▁▁▁▁▁▁▁▁████████▁",
+            "▁▁▁▁▁▁▁▁▁▁▁████████▁",
+            "▁▁▁▁▁▁▁▁▁▁▁▁███████▁",
+            "▁▁▁▁▁▁▁▁▁▁▁▁███████▁",
+            "▁▁▁▁▁▁▁▁▁▁▁▁▁███████",
+            "▁▁▁▁▁▁▁▁▁▁▁▁▁███████",
+            "▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█████",
+            "▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁████",
+            "▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁████",
+            "▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁████",
+            "▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁███",
+            "▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁███",
+            "▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁██",
+            "▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁██",
+            "▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁██",
+            "▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█",
+            "▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█",
+            "▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█",
+            "▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁",
+            "▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁",
+            "▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁",
+            "▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁"
+        ], interval: 17);
+
+        public static readonly Pattern Moon = new([
             "🌑 ",
             "🌒 ",
             "🌓 ",
@@ -702,16 +1080,14 @@ namespace Kurukuru
             "🌖 ",
             "🌗 ",
             "🌘 "
-        }, interval: 80);
+        ], interval: 80);
 
-        public static readonly Pattern Runner = new Pattern(new string[]
-        {
+        public static readonly Pattern Runner = new([
             "🚶 ",
             "🏃 "
-        }, interval: 140);
+        ], interval: 140);
 
-        public static readonly Pattern Pong = new Pattern(new string[]
-        {
+        public static readonly Pattern Pong = new([
             "▐⠂       ▌",
             "▐⠈       ▌",
             "▐ ⠂      ▌",
@@ -742,10 +1118,9 @@ namespace Kurukuru
             "▐ ⠠      ▌",
             "▐ ⡀      ▌",
             "▐⠠       ▌"
-        }, interval: 80);
+        ], interval: 80);
 
-        public static readonly Pattern Shark = new Pattern(new string[]
-        {
+        public static readonly Pattern Shark = new([
             "▐|\\____________▌",
             "▐_|\\___________▌",
             "▐__|\\__________▌",
@@ -772,18 +1147,16 @@ namespace Kurukuru
             "▐__/|__________▌",
             "▐_/|___________▌",
             "▐/|____________▌"
-        }, interval: 120);
+        ], interval: 120);
 
-        public static readonly Pattern Dqpb = new Pattern(new string[]
-        {
+        public static readonly Pattern Dqpb = new([
             "d",
             "q",
             "p",
             "b"
-        }, interval: 100);
+        ], interval: 100);
 
-        public static readonly Pattern Weather = new Pattern(new string[]
-        {
+        public static readonly Pattern Weather = new([
             "☀️ ",
             "☀️ ",
             "☀️ ",
@@ -807,24 +1180,301 @@ namespace Kurukuru
             "🌤 ",
             "☀️ ",
             "☀️ "
-        }, interval: 100);
+        ], interval: 100);
 
-        public static readonly Pattern Christmas = new Pattern(new string[]
-        {
+        public static readonly Pattern Christmas = new([
             "🌲",
             "🎄"
-        }, interval: 400);
-    }
+        ], interval: 400);
 
-    public class Pattern
-    {
-        public string[] Frames { get; }
-        public int Interval { get; }
+        public static readonly Pattern Grenade = new([
+            "،  ",
+            "′  ",
+            " ´ ",
+            " ‾ ",
+            "  ⸌",
+            "  ⸊",
+            "  |",
+            "  ⁎",
+            "  ⁕",
+            " ෴ ",
+            "  ⁓",
+            "   ",
+            "   ",
+            "   "
+        ], interval: 80);
 
-        public Pattern(string[] frames, int interval)
-        {
-            Frames = frames;
-            Interval = interval;
-        }
+        public static readonly Pattern Point = new([
+            "∙∙∙",
+            "●∙∙",
+            "∙●∙",
+            "∙∙●",
+            "∙∙∙"
+        ], interval: 125);
+
+        public static readonly Pattern Layer = new([
+            "-",
+            "=",
+            "≡"
+        ], interval: 150);
+
+        public static readonly Pattern BetaWave = new([
+            "ρββββββ",
+            "βρβββββ",
+            "ββρββββ",
+            "βββρβββ",
+            "ββββρββ",
+            "βββββρβ",
+            "ββββββρ"
+        ], interval: 80);
+
+        public static readonly Pattern FingerDance = new([
+            "🤘 ",
+            "🤟 ",
+            "🖖 ",
+            "✋ ",
+            "🤚 ",
+            "👆 "
+        ], interval: 160);
+
+        public static readonly Pattern FistBump = new([
+            "🤜　　　　🤛 ",
+            "🤜　　　　🤛 ",
+            "🤜　　　　🤛 ",
+            "　🤜　　🤛　 ",
+            "　　🤜🤛　　 ",
+            "　🤜✨🤛　　 ",
+            "🤜　✨　🤛　 "
+        ], interval: 80);
+
+        public static readonly Pattern SoccerHeader = new([
+            " 🧑⚽️       🧑 ",
+            "🧑  ⚽️      🧑 ",
+            "🧑   ⚽️     🧑 ",
+            "🧑    ⚽️    🧑 ",
+            "🧑     ⚽️   🧑 ",
+            "🧑      ⚽️  🧑 ",
+            "🧑       ⚽️🧑  ",
+            "🧑      ⚽️  🧑 ",
+            "🧑     ⚽️   🧑 ",
+            "🧑    ⚽️    🧑 ",
+            "🧑   ⚽️     🧑 ",
+            "🧑  ⚽️      🧑 "
+        ], interval: 80);
+
+        public static readonly Pattern Mindblown = new([
+            "😐 ",
+            "😐 ",
+            "😮 ",
+            "😮 ",
+            "😦 ",
+            "😦 ",
+            "😧 ",
+            "😧 ",
+            "🤯 ",
+            "💥 ",
+            "✨ ",
+            "　 ",
+            "　 ",
+            "　 "
+        ], interval: 160);
+
+        public static readonly Pattern Speaker = new([
+            "🔈 ",
+            "🔉 ",
+            "🔊 ",
+            "🔉 "
+        ], interval: 160);
+
+        public static readonly Pattern OrangePulse = new([
+            "🔸 ",
+            "🔶 ",
+            "🟠 ",
+            "🟠 ",
+            "🔶 "
+        ], interval: 100);
+
+        public static readonly Pattern BluePulse = new([
+            "🔹 ",
+            "🔷 ",
+            "🔵 ",
+            "🔵 ",
+            "🔷 "
+        ], interval: 100);
+
+        public static readonly Pattern OrangeBluePulse = new([
+            "🔸 ",
+            "🔶 ",
+            "🟠 ",
+            "🟠 ",
+            "🔶 ",
+            "🔹 ",
+            "🔷 ",
+            "🔵 ",
+            "🔵 ",
+            "🔷 "
+        ], interval: 100);
+
+        public static readonly Pattern TimeTravel = new([
+            "🕛 ",
+            "🕚 ",
+            "🕙 ",
+            "🕘 ",
+            "🕗 ",
+            "🕖 ",
+            "🕕 ",
+            "🕔 ",
+            "🕓 ",
+            "🕒 ",
+            "🕑 ",
+            "🕐 "
+        ], interval: 100);
+
+        public static readonly Pattern Aesthetic = new([
+            "▰▱▱▱▱▱▱",
+            "▰▰▱▱▱▱▱",
+            "▰▰▰▱▱▱▱",
+            "▰▰▰▰▱▱▱",
+            "▰▰▰▰▰▱▱",
+            "▰▰▰▰▰▰▱",
+            "▰▰▰▰▰▰▰",
+            "▰▱▱▱▱▱▱"
+        ], interval: 80);
+
+        public static readonly Pattern DwarfFortress = new([
+            " ██████£££  ",
+            "☺██████£££  ",
+            "☺██████£££  ",
+            "☺▓█████£££  ",
+            "☺▓█████£££  ",
+            "☺▒█████£££  ",
+            "☺▒█████£££  ",
+            "☺░█████£££  ",
+            "☺░█████£££  ",
+            "☺ █████£££  ",
+            " ☺█████£££  ",
+            " ☺█████£££  ",
+            " ☺▓████£££  ",
+            " ☺▓████£££  ",
+            " ☺▒████£££  ",
+            " ☺▒████£££  ",
+            " ☺░████£££  ",
+            " ☺░████£££  ",
+            " ☺ ████£££  ",
+            "  ☺████£££  ",
+            "  ☺████£££  ",
+            "  ☺▓███£££  ",
+            "  ☺▓███£££  ",
+            "  ☺▒███£££  ",
+            "  ☺▒███£££  ",
+            "  ☺░███£££  ",
+            "  ☺░███£££  ",
+            "  ☺ ███£££  ",
+            "   ☺███£££  ",
+            "   ☺███£££  ",
+            "   ☺▓██£££  ",
+            "   ☺▓██£££  ",
+            "   ☺▒██£££  ",
+            "   ☺▒██£££  ",
+            "   ☺░██£££  ",
+            "   ☺░██£££  ",
+            "   ☺ ██£££  ",
+            "    ☺██£££  ",
+            "    ☺██£££  ",
+            "    ☺▓█£££  ",
+            "    ☺▓█£££  ",
+            "    ☺▒█£££  ",
+            "    ☺▒█£££  ",
+            "    ☺░█£££  ",
+            "    ☺░█£££  ",
+            "    ☺ █£££  ",
+            "     ☺█£££  ",
+            "     ☺█£££  ",
+            "     ☺▓£££  ",
+            "     ☺▓£££  ",
+            "     ☺▒£££  ",
+            "     ☺▒£££  ",
+            "     ☺░£££  ",
+            "     ☺░£££  ",
+            "     ☺ £££  ",
+            "      ☺£££  ",
+            "      ☺£££  ",
+            "      ☺▓££  ",
+            "      ☺▓££  ",
+            "      ☺▒££  ",
+            "      ☺▒££  ",
+            "      ☺░££  ",
+            "      ☺░££  ",
+            "      ☺ ££  ",
+            "       ☺££  ",
+            "       ☺££  ",
+            "       ☺▓£  ",
+            "       ☺▓£  ",
+            "       ☺▒£  ",
+            "       ☺▒£  ",
+            "       ☺░£  ",
+            "       ☺░£  ",
+            "       ☺ £  ",
+            "        ☺£  ",
+            "        ☺£  ",
+            "        ☺▓  ",
+            "        ☺▓  ",
+            "        ☺▒  ",
+            "        ☺▒  ",
+            "        ☺░  ",
+            "        ☺░  ",
+            "        ☺   ",
+            "        ☺  &",
+            "        ☺ ☼&",
+            "       ☺ ☼ &",
+            "       ☺☼  &",
+            "      ☺☼  & ",
+            "      ‼   & ",
+            "     ☺   &  ",
+            "    ‼    &  ",
+            "   ☺    &   ",
+            "  ‼     &   ",
+            " ☺     &    ",
+            "‼      &    ",
+            "      &     ",
+            "      &     ",
+            "     &   ░  ",
+            "     &   ▒  ",
+            "    &    ▓  ",
+            "    &    £  ",
+            "   &    ░£  ",
+            "   &    ▒£  ",
+            "  &     ▓£  ",
+            "  &     ££  ",
+            " &     ░££  ",
+            " &     ▒££  ",
+            "&      ▓££  ",
+            "&      £££  ",
+            "      ░£££  ",
+            "      ▒£££  ",
+            "      ▓£££  ",
+            "      █£££  ",
+            "     ░█£££  ",
+            "     ▒█£££  ",
+            "     ▓█£££  ",
+            "     ██£££  ",
+            "    ░██£££  ",
+            "    ▒██£££  ",
+            "    ▓██£££  ",
+            "    ███£££  ",
+            "   ░███£££  ",
+            "   ▒███£££  ",
+            "   ▓███£££  ",
+            "   ████£££  ",
+            "  ░████£££  ",
+            "  ▒████£££  ",
+            "  ▓████£££  ",
+            "  █████£££  ",
+            " ░█████£££  ",
+            " ▒█████£££  ",
+            " ▓█████£££  ",
+            " ██████£££  ",
+            " ██████£££  "
+        ], interval: 80);
     }
 }

--- a/UpdatePatterns.js
+++ b/UpdatePatterns.js
@@ -1,0 +1,15 @@
+// The patterns are ripped off https://github.com/sindresorhus/cli-spinners
+const res = await fetch("https://raw.githubusercontent.com/sindresorhus/cli-spinners/refs/heads/main/spinners.json");
+const json = JSON.parse(await res.text());
+const patterns = Object.keys(json).map(x => ({ key: x[0].toUpperCase() + x.substring(1), value: json[x] })).map(x => [`        public static readonly Pattern ${x.key} = new([`, x.value.frames.map(x => '            "' + x.replace('\\', '\\\\') + '"').join(",\n"), `        ], interval: ${x.value.interval});`].join("\n")).join("\n\n");
+
+const cs = `namespace Kurukuru
+{
+    // The patterns are ripped off https://github.com/sindresorhus/cli-spinners
+    public class Patterns
+    {
+${patterns}
+    }
+}`;
+
+console.log(cs)


### PR DESCRIPTION
Updated to follow the latest changes in `spinners.json` from https://github.com/sindresorhus/cli-spinners.

Also, since .NET 5 is no longer supported, I updated workflows to target .NET 8 instead.
There’s no .NET 5-specific logic in Kurukuru.dll, so I removed `net5.0` from the TargetFrameworks.