### PR TITLE
Suppress flicker

### DIFF
--- a/Kurukuru/ConsoleHelper.cs
+++ b/Kurukuru/ConsoleHelper.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.InteropServices;
 
 namespace Kurukuru
 {
@@ -46,23 +45,32 @@ namespace Kurukuru
             Console.ForegroundColor = foregroundColor;
         }
 
-        // See: https://stackoverflow.com/questions/8946808/can-console-clear-be-used-to-only-clear-a-line-instead-of-whole-console/8946847#8946847
-        public static void ClearCurrentConsoleLine(int length, int top)
+        public static void RewriteConsoleLine(int length, int top, Action writeAction)
         {
-            if (Console.IsOutputRedirected) return;
+            if (Console.IsOutputRedirected)
+            {
+                writeAction();
+                return;
+            }
 
+            Console.SetCursorPosition(0, top);
             if (CanAcceptEscapeSequence)
             {
-                Console.SetCursorPosition(0, top);
-                Console.Write("\u001B[2K");
+                writeAction();
+                Console.Write("\u001B[0K");
             }
             else
             {
-                Console.SetCursorPosition(0, top);
-                Console.Write(new string(' ', length));
-                Console.SetCursorPosition(0, top);
+                writeAction();
+
+                // See: https://stackoverflow.com/questions/8946808/can-console-clear-be-used-to-only-clear-a-line-instead-of-whole-console/8946847#8946847
+                var currentLeft = Console.CursorLeft;
+                if (length > currentLeft)
+                {
+                    Console.Write(new string(' ', length - currentLeft));
+                }
+                Console.SetCursorPosition(currentLeft, top);
             }
-            Console.Out.Flush();
         }
 
         public static void SetCursorVisibility(bool visible)

--- a/Kurukuru/Spinner.cs
+++ b/Kurukuru/Spinner.cs
@@ -126,8 +126,17 @@ namespace Kurukuru
 
         private void Render(string terminator)
         {
-            var pattern = CurrentPattern;
-            var frame = pattern.Frames[_frameIndex++ % pattern.Frames.Length];
+            int RenderBody()
+            {
+                var pattern = CurrentPattern;
+                var frame = pattern.Frames[_frameIndex++ % pattern.Frames.Length];
+
+                ConsoleHelper.WriteWithColor(frame, Color ?? Console.ForegroundColor);
+                Console.Write(' ');
+                Console.Write(Text);
+
+                return frame.Length + 1 + Text.Length;
+            }
 
             lock (s_consoleLock)
             {
@@ -138,11 +147,11 @@ namespace Kurukuru
                         var currentLeft = Console.CursorLeft;
                         var currentTop = Console.CursorTop;
 
-                        ConsoleHelper.ClearCurrentConsoleLine(_lineLength, _enabled ? _cursorTop : currentTop);
-                        ConsoleHelper.WriteWithColor(frame, Color ?? Console.ForegroundColor);
-                        Console.Write(" ");
-                        Console.Write(Text);
-                        _lineLength = Console.CursorLeft; // get line length before write terminator
+                        ConsoleHelper.RewriteConsoleLine(_lineLength, _enabled ? _cursorTop : currentTop, () =>
+                        {
+                            RenderBody();
+                            _lineLength = Console.CursorLeft; // get line length before write terminator
+                        });
                         Console.Write(terminator);
                         Console.Out.Flush();
 
@@ -150,11 +159,8 @@ namespace Kurukuru
                     }
                     else
                     {
-
-                        ConsoleHelper.WriteWithColor(frame, Color ?? Console.ForegroundColor);
-                        Console.Write(" ");
-                        Console.Write(Text);
-                        _lineLength = frame.Length + 1 + Text.Length;
+                        var length = RenderBody();
+                        _lineLength = length;
                         Console.Write(terminator);
                         Console.Out.Flush();
                     }


### PR DESCRIPTION
## The current implementation

1.  Deletes the previously displayed line
2.  Draws the new line

This order can cause flickering depending on the drawing timing.


https://github.com/user-attachments/assets/f6d309ba-db8f-4299-85cc-845b22c76cd0

## My implementation

1.  Draws the new line
2.   If the previously displayed line still remains, delete it

This order suppress flickering.

https://github.com/user-attachments/assets/5a65d6cd-e291-4897-b3f4-5c03c1f3ec5c

